### PR TITLE
feat: Adds symbols commands to raygun-cli

### DIFF
--- a/raygun-cli/README.md
+++ b/raygun-cli/README.md
@@ -43,6 +43,11 @@ Or use directly from sources:
 dart bin/raygun_cli.dart <command> <arguments>
 ```
 
+**Common mandatory arguments**
+
+- `app-id` the Application ID in Raygun.com.
+- `token` is an access token from https://app.raygun.com/user/tokens.
+
 #### Sourcemap Uploader
 
 Upload sourcemaps to [raygun.com](https://raygun.com).
@@ -54,8 +59,6 @@ raygun-cli sourcemap <arguments>
 Where the arguments are:
 
 - `uri` is the full URI where your project will be installed to.
-- `app-id` the Application ID in Raygun.com.
-- `token` is an access token from https://app.raygun.com/user/tokens.
 - `input-map` is the map file to upload.
 
 ```
@@ -78,6 +81,66 @@ raygun-cli sourcemap -p flutter --uri=https://example.com/main.dart.js --app-id=
 ##### NodeJS Sourcemaps
 
 _Not available yet!_
+
+#### Flutter obfuscation symbols
+
+Manages obfuscation symbols to [raygun.com](https://raygun.com).
+
+```
+raygun-cli symbols <subcommand> <arguments>
+```
+
+**Subcommands**
+
+- `upload`: Upload a symbols file.
+- `list`: List uploaded symbols files.
+- `delete`: Delete an uploaded symbols file.
+
+**Upload subcommand**
+
+Upload a symbols file.
+
+Provide the path to the symbols file (e.g. `app.android-arm64.symbols`), as well as the application version (e.g. `1.0.0`).
+
+```
+raygun-cli symbols upload --path=<path to symbols file> --version=<app version> --app-id=APP_ID --token=TOKEN
+```
+
+**List subcommand**
+
+List the uploaded symbols file.
+
+```
+raygun-cli symbols list --app-id=APP_ID --token=TOKEN
+```
+
+Example output:
+
+```
+List of symbols:
+
+Symbols File: app.android-arm64.symbols
+Identifier: 2c7a3u3
+App Version: 0.0.1
+
+Symbols File: app.android-x64.symbols
+Identifier: 2c7a3u4
+App Version: 0.0.1
+
+Symbols File: app.android-arm.symbols
+Identifier: 2c7a7k6
+App Version: 0.0.1
+```
+
+**Delete subcommand**
+
+Delete an uploaded symbols file.
+
+Provide the id of the symbols file (e.g. `abcd1234`). You can obtain the id with the `list` subcommand.
+
+```
+raygun-cli symbols delete --id=<id> --app-id=APP_ID --token=TOKEN
+```
 
 ## Development
 

--- a/raygun-cli/README.md
+++ b/raygun-cli/README.md
@@ -136,7 +136,7 @@ App Version: 0.0.1
 
 Delete an uploaded symbols file.
 
-Provide the id of the symbols file (e.g. `abcd1234`). You can obtain the id with the `list` subcommand.
+Provide the identifier (`id`) of the symbols file (e.g. `--id=2c7a3u3`). You can obtain the identifier with the `list` subcommand.
 
 ```
 raygun-cli symbols delete --id=<id> --app-id=APP_ID --token=TOKEN

--- a/raygun-cli/bin/raygun_cli.dart
+++ b/raygun-cli/bin/raygun_cli.dart
@@ -1,5 +1,6 @@
 import 'package:args/args.dart';
 import 'package:raygun_cli/sourcemap/sourcemap_command.dart';
+import 'package:raygun_cli/symbols/flutter_symbols.dart';
 
 const String version = '0.0.1';
 
@@ -25,6 +26,10 @@ ArgParser buildParser() {
     ..addCommand(
       kSourcemapCommand,
       buildParserSourcemap(),
+    )
+    ..addCommand(
+      kSymbolsCommand,
+      buildParserSymbols(),
     );
 }
 
@@ -53,6 +58,11 @@ void main(List<String> arguments) {
 
     if (results.command?.name == kSourcemapCommand) {
       parseSourcemapCommand(results.command!, verbose);
+      return;
+    }
+
+    if (results.command?.name == kSymbolsCommand) {
+      parseSymbolsCommand(results.command!, verbose);
       return;
     }
 

--- a/raygun-cli/lib/symbols/flutter_symbols.dart
+++ b/raygun-cli/lib/symbols/flutter_symbols.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:raygun_cli/symbols/flutter_symbols_api.dart';
+
+const kSymbolsCommand = 'symbols';
+
+void parseSymbolsCommand(ArgResults command, bool verbose) {
+  if (command.wasParsed('help')) {
+    print(
+        'Usage: raygun-cli $kSymbolsCommand (upload|list|delete) <arguments>');
+    print(buildParserSymbols().usage);
+    exit(0);
+  }
+  if (!command.wasParsed('app-id') || !command.wasParsed('token')) {
+    print('Missing mandatory arguments');
+    print(buildParserSymbols().usage);
+    exit(2);
+  }
+  _run(
+    command: command,
+    appId: command['app-id'],
+    token: command['token'],
+  ).then((result) {
+    if (result) {
+      exit(0);
+    } else {
+      exit(2);
+    }
+  }).catchError((e) {
+    print('Error: $e');
+    exit(2);
+  });
+}
+
+Future<bool> _run({
+  required ArgResults command,
+  required appId,
+  required token,
+}) async {
+  if (command.command?.name == 'upload') {
+    if (!command.wasParsed('path') || !command.wasParsed('version')) {
+      print('Missing mandatory arguments');
+      print(buildParserSymbols().usage);
+      return false;
+    }
+    final path = command['path'];
+    final version = command['version'];
+    return uploadSymbols(
+      appId: appId,
+      token: token,
+      path: path,
+      version: version,
+    );
+  }
+
+  if (command.command?.name == 'list') {
+    return listSymbols(
+      appId: appId,
+      token: token,
+    );
+  }
+
+  if (command.command?.name == 'delete') {
+    if(!command.wasParsed('id')) {
+      print('Missing mandatory arguments');
+      print(buildParserSymbols().usage);
+      return false;
+    }
+    return deleteSymbols(
+      appId: appId,
+      token: token,
+      id: command['id'],
+    );
+  }
+
+  return false;
+}
+
+ArgParser buildParserSymbols() {
+  return ArgParser()
+    ..addFlag(
+      'help',
+      abbr: 'h',
+      negatable: false,
+      help: 'Print $kSymbolsCommand usage information.',
+    )
+    ..addOption(
+      'app-id',
+      help: 'Raygun\'s application ID',
+      mandatory: true,
+    )
+    ..addOption(
+      'token',
+      help: 'Raygun\'s access token',
+      mandatory: true,
+    )
+    ..addOption(
+      'path',
+      help: 'Path to symbols file, used in upload',
+    )
+    ..addOption(
+      'version',
+      help: 'App version, used in upload',
+    )
+    ..addOption(
+      'id',
+      help: 'Symbol ID, used in delete',
+    )
+    ..addCommand(
+      'upload',
+    )
+    ..addCommand(
+      'list',
+    )
+    ..addCommand(
+      'delete',
+    );
+}

--- a/raygun-cli/lib/symbols/flutter_symbols_api.dart
+++ b/raygun-cli/lib/symbols/flutter_symbols_api.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:http/http.dart' as http;
+
+Future<bool> uploadSymbols({
+  required String appId,
+  required String token,
+  required String path,
+  required String version,
+}) async {
+  final file = File(path);
+  if (!file.existsSync()) {
+    print('$path: file not found!');
+    return false;
+  }
+  print('Uploading: $path');
+
+  final url = 'https://api.raygun.com/v3/applications/$appId/flutter-symbols';
+  final request = http.MultipartRequest('PUT', Uri.parse(url));
+  request.headers.addAll({
+    'Authorization': 'Bearer $token',
+    'Content-Type': 'multipart/form-data',
+  });
+  request.files.add(
+    http.MultipartFile(
+      'file',
+      file.readAsBytes().asStream(),
+      file.lengthSync(),
+      filename: path.split("/").last,
+    ),
+  );
+  request.fields.addAll({
+    'version': version,
+  });
+  final res = await request.send();
+  if (res.statusCode == 200) {
+    print('File uploaded succesfully!');
+    return true;
+  } else {
+    print('Error uploading file. Response code: ${res.statusCode}');
+    return false;
+  }
+}
+
+Future<bool> listSymbols({
+  required String appId,
+  required String token,
+}) async {
+  final url = 'https://api.raygun.com/v3/applications/$appId/flutter-symbols';
+  final request = http.MultipartRequest('GET', Uri.parse(url));
+  request.headers.addAll({
+    'Authorization': 'Bearer $token',
+    'Content-Type': 'multipart/form-data',
+  });
+  final res = await request.send();
+  if (res.statusCode == 200) {
+    final string = await res.stream.bytesToString();
+    final listItems = jsonDecode(string) as List<dynamic>;
+    print('');
+    print('List of symbols:');
+    print('');
+    for (final item in listItems) {
+      print('Symbols File: ${item['name']}');
+      print('Identifier: ${item['identifier']}');
+      print('App Version: ${item['version']}');
+      print('');
+    }
+    return true;
+  } else {
+    print('Error getting list. Response code: ${res.statusCode}');
+    return false;
+  }
+}
+
+Future<bool> deleteSymbols({
+  required String appId,
+  required String token,
+  required String id,
+}) async {
+  final url =
+      'https://api.raygun.com/v3/applications/$appId/flutter-symbols/$id';
+  final request = http.MultipartRequest('DELETE', Uri.parse(url));
+  request.headers.addAll({
+    'Authorization': 'Bearer $token',
+    'Content-Type': 'multipart/form-data',
+  });
+  final res = await request.send();
+  if (res.statusCode == 204) {
+    print('Deleted: $id');
+    return true;
+  } else {
+    print('Error deleting $id. Response code: ${res.statusCode}');
+    return false;
+  }
+}


### PR DESCRIPTION
This PR adds the `symbols` command to the `raygun-cli` tool.

README contains all the info on the new commands, here are some examples:

Upload:

```
dart run raygun_cli:raygun_cli symbols upload --app-id=[REDACTED] --token=[REDACTED] --path=[REDACTED]/raygun/raygun4flutter/example/symbols/app.android-x64.symbols --version=0.0.1

Building package executable... 
Built raygun_cli:raygun_cli.
Uploading: [REDACTED]/raygun/raygun4flutter/example/symbols/app.android-x64.symbols
File uploaded succesfully!
```

List:

```
dart run raygun_cli:raygun_cli symbols list --app-id=[REDACTED] --token=[REDACTED]

Building package executable... 
Built raygun_cli:raygun_cli.

List of symbols:

Symbols File: app.android-arm64.symbols
Identifier: 2c7a3u3
App Version: 0.0.1

Symbols File: app.android-x64.symbols
Identifier: 2c7a3u4
App Version: 0.0.1

Symbols File: app.android-arm.symbols
Identifier: 2c7a7k6
App Version: 0.0.1
```

Delete:

```
dart run raygun_cli:raygun_cli symbols delete --id=2c7a3u4 --app-id=[REDACTED] --token=[REDACTED]

Building package executable... 
Built raygun_cli:raygun_cli.
Deleted: 2c7a3u4
```

FYI @MattByers 