### PR TITLE
chore(raygun-cli): Prepare release 0.0.2

### DIFF
--- a/raygun-cli/CHANGELOG.md
+++ b/raygun-cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+- Adds the `symbols` command to upload/list/delete Flutter symbols files on Raygun.com
+
 ## 0.0.1
 
 - Adds the `sourcemap` command to upload JavaScript sourcemaps to Raygun.com

--- a/raygun-cli/pubspec.yaml
+++ b/raygun-cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: raygun_cli
 description: Command-line tool for Raygun.com
-version: 0.0.1
+version: 0.0.2
 repository: https://github.com/MindscapeHQ/raygun-toolbox/
 homepage: https://raygun.com
 


### PR DESCRIPTION
This release adds the functionality to upload/list/delete symbols files for Flutter.

Once the tool is published, we can add this to the Flutter provider README